### PR TITLE
Correccion Intermitencia e inestabilidad #25

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - main
-      - dev
   pull_request:
     branches:
       - main
-      - dev
 
 jobs:
   build-and-test:

--- a/.github/workflows/qa_torneofutbolapp-qa.yml
+++ b/.github/workflows/qa_torneofutbolapp-qa.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - qa
+  pull_request:
+    branches:
+      - qa
   workflow_dispatch:
 
 jobs:

--- a/Torneo.App/Torneo.App.Frontend/secrets.json
+++ b/Torneo.App/Torneo.App.Frontend/secrets.json
@@ -1,5 +1,5 @@
 {
-  "ConnectionStrings:IdentityDataContextConnection": "Server=tcp:torneo-futbol.database.windows.net,1433;Initial Catalog=Torneo;Persist Security Info=False;User ID=admin1;Password='Torneo;App.';MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
-  "_Local_ConnectionStrings:IdentityDataContextConnection": "Data Source = (localdb)\\MSSQLLocalDB; Initial Catalog = Torneo",
+  "__ConnectionStrings:IdentityDataContextConnection": "Server=tcp:torneo-futbol.database.windows.net,1433;Initial Catalog=Torneo;Persist Security Info=False;User ID=admin1;Password='Torneo;App.';MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
+  "ConnectionStrings:IdentityDataContextConnection": "Data Source = (localdb)\\MSSQLLocalDB; Initial Catalog = Torneo",
    "_Docker_ConnectionStrings:IdentityDataContextConnection": "Server=tcp:sql-server,1433;Database=Torneo;User Id=sa;Password=LocalDB2017;MultipleActiveResultSets=true;Encrypt=False"  
 }

--- a/Torneo.App/Torneo.App.Frontend/secrets.json
+++ b/Torneo.App/Torneo.App.Frontend/secrets.json
@@ -1,5 +1,5 @@
 {
-  "__ConnectionStrings:IdentityDataContextConnection": "Server=tcp:torneo-futbol.database.windows.net,1433;Initial Catalog=Torneo;Persist Security Info=False;User ID=admin1;Password='Torneo;App.';MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
-  "ConnectionStrings:IdentityDataContextConnection": "Data Source = (localdb)\\MSSQLLocalDB; Initial Catalog = Torneo",
+  "ConnectionStrings:IdentityDataContextConnection": "Server=tcp:torneo-futbol.database.windows.net,1433;Initial Catalog=Torneo;Persist Security Info=False;User ID=admin1;Password='Torneo;App.';MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
+  "___ConnectionStrings:IdentityDataContextConnection": "Data Source = (localdb)\\MSSQLLocalDB; Initial Catalog = Torneo",
    "_Docker_ConnectionStrings:IdentityDataContextConnection": "Server=tcp:sql-server,1433;Database=Torneo;User Id=sa;Password=LocalDB2017;MultipleActiveResultSets=true;Encrypt=False"  
 }

--- a/Torneo.App/Torneo.App.Persistencia/AppRepositorios/RepositorioDT.cs
+++ b/Torneo.App/Torneo.App.Persistencia/AppRepositorios/RepositorioDT.cs
@@ -17,11 +17,12 @@ namespace Torneo.App.Persistencia
         {
              var Dts = _dataContext.DirectoresTecnicos
                             .Include(e => e.Equipos)
+                            .AsNoTracking()
                             .ToList();
 
-            _dataContext.ChangeTracker.Clear();
+            /*_dataContext.ChangeTracker.Clear();
             _dataContext.Dispose();
-            _dataContext = new DataContext();
+            _dataContext = new DataContext();*/
             
             return Dts;
         }

--- a/Torneo.App/Torneo.App.Persistencia/AppRepositorios/RepositorioEquipo.cs
+++ b/Torneo.App/Torneo.App.Persistencia/AppRepositorios/RepositorioEquipo.cs
@@ -25,10 +25,11 @@ namespace Torneo.App.Persistencia
                             .Include(e => e.Jugadores)
                             .Include(e => e.PartidosLocal)                         
                             .Include(e => e.PartidosVisitante)                         
+                            .AsNoTracking()
                             .ToList();
-            _dataContext.ChangeTracker.Clear();
+           /* _dataContext.ChangeTracker.Clear();
             _dataContext.Dispose();
-            _dataContext = new DataContext();           
+            _dataContext = new DataContext();*/
                             
             return equipos;
         }
@@ -84,6 +85,7 @@ namespace Torneo.App.Persistencia
                         .Include(e => e.Jugadores) // Carga explicita
                         .Include(e => e.PartidosLocal)       // Carga explicita                   
                         .Include(e => e.PartidosVisitante) // Carga explicita
+                        .AsNoTracking()
                         .ToList();
             return equipos;
         }

--- a/Torneo.App/Torneo.App.Persistencia/AppRepositorios/RepositorioJugador.cs
+++ b/Torneo.App/Torneo.App.Persistencia/AppRepositorios/RepositorioJugador.cs
@@ -20,6 +20,7 @@ namespace Torneo.App.Persistencia
             var jugadores = _dataContext.Jugadores
                             .Include(j => j.Equipo)
                             .Include(j => j.Posicion)
+                            .AsNoTracking()
                             .ToList();
  
             

--- a/Torneo.App/Torneo.App.Persistencia/AppRepositorios/RepositorioMunicipio.cs
+++ b/Torneo.App/Torneo.App.Persistencia/AppRepositorios/RepositorioMunicipio.cs
@@ -15,11 +15,12 @@ namespace Torneo.App.Persistencia
         {
             var municipios = _dataContext.Municipios
             .Include(m => m.Equipos)
+            .AsNoTracking()
             .ToList();
 
-            _dataContext.ChangeTracker.Clear();
+            /*_dataContext.ChangeTracker.Clear();
             _dataContext.Dispose();
-            _dataContext = new DataContext();   
+            _dataContext = new DataContext();*/
 
             return municipios;
         }

--- a/Torneo.App/Torneo.App.Persistencia/AppRepositorios/RepositorioPartido.cs
+++ b/Torneo.App/Torneo.App.Persistencia/AppRepositorios/RepositorioPartido.cs
@@ -20,10 +20,11 @@ namespace Torneo.App.Persistencia
             var partidos = _dataContext.Partidos
                             .Include(p => p.Local)
                             .Include(p => p.Visitante)
+                            .AsNoTracking()
                             .ToList();
-            _dataContext.ChangeTracker.Clear();
+            /*_dataContext.ChangeTracker.Clear();
             _dataContext.Dispose();
-            _dataContext = new DataContext();   
+            _dataContext = new DataContext();*/
                             
             return partidos;
         }
@@ -32,6 +33,7 @@ namespace Torneo.App.Persistencia
             var partido = _dataContext.Partidos
                             .Include(p => p.Local)
                             .Include(p => p.Visitante)
+                            .AsNoTracking()
                             .FirstOrDefault(p => p.Id == idPartido);
             return partido ?? throw new Exception("Partido not found");  // Throw an exception if partido is null.
         }
@@ -53,9 +55,9 @@ namespace Torneo.App.Persistencia
                 Console.WriteLine("No se encontró el partido");
             }
 
-            _dataContext.ChangeTracker.Clear();
+            /*_dataContext.ChangeTracker.Clear();
             _dataContext.Dispose();
-            _dataContext = new DataContext();
+            _dataContext = new DataContext();*/
             return partidoEncontrado ?? throw new Exception("Partido not found");  // Throw an exception if partidoEncontrado is null.
         }
 
@@ -67,9 +69,10 @@ namespace Torneo.App.Persistencia
                 
                 _dataContext.Partidos.Remove(partidoEncontrado);
                 _dataContext.SaveChanges();
-                _dataContext.ChangeTracker.Clear();
+                
+                /*_dataContext.ChangeTracker.Clear();
                 _dataContext.Dispose();
-                _dataContext = new DataContext();
+                _dataContext = new DataContext();*/
                 
                 
             } else

--- a/Torneo.App/Torneo.App.Persistencia/AppRepositorios/RepositorioPosicion.cs
+++ b/Torneo.App/Torneo.App.Persistencia/AppRepositorios/RepositorioPosicion.cs
@@ -15,11 +15,12 @@ namespace Torneo.App.Persistencia
         {   
             var posiciones = _dataContext.Posiciones
                                 .Include(p => p.Jugadores)
+                                .AsNoTracking()
                                 .ToList();
 
-            _dataContext.ChangeTracker.Clear();
+            /*_dataContext.ChangeTracker.Clear();
             _dataContext.Dispose();
-            _dataContext = new DataContext();   
+            _dataContext = new DataContext();*/
 
             return posiciones ?? throw new Exception("Posiciones not found");  // Throw an exception if posiciones is null.
         }


### PR DESCRIPTION
Correccion Intermitencia e inestabilidad al navagar en la web app - Issue #25 

Se revierten los cambios que  liberaraban, borraba y recreaban el contexto del modelo y limpiaban el ChangeTracker lo que ocasionaba dicha intermitencia de conexion con la base de datos; este cambio hacia que se actualizaban en tiempo real las referencias a los nombres y demas atributos de otras entidades al momento de editarlas. Asi mismo se implementa otra solución para refrescar los datos referenciales de otras entidades en tiempo real.

 


